### PR TITLE
Moralis.Units.FromWei undefined on cloud function

### DIFF
--- a/moralis-server/tools/moralis-units.md
+++ b/moralis-server/tools/moralis-units.md
@@ -43,7 +43,6 @@ const tokenValue = Moralis.Units.FromWei("2000000000000000000", 6)
 const tokenValue = Moralis.Units.FromWei("2000000000000000000")
 ```
 Note that this function is not available on cloud code. You can use it in the SDK only. We are very soon adding it to cloud code.
-In the meantime, In javascript it would be wei = eth_amount*10e17. Not *10e18 . e counts as the 10 and *10e18 would multiply your eth by one order of magnitude too many!
 
 Web3 API responses for token balances have **decimals **and **balance **in Wei fields:
 

--- a/moralis-server/tools/moralis-units.md
+++ b/moralis-server/tools/moralis-units.md
@@ -42,7 +42,7 @@ const tokenValue = Moralis.Units.FromWei("2000000000000000000", 6)
 //If you do not specify decimals, 18 decimals will be automatically used
 const tokenValue = Moralis.Units.FromWei("2000000000000000000")
 ```
-Note that this function is not available on cloud code. You can use it in the SDK only.
+Note that this function is not available on cloud code. You can use it in the SDK only. We are very soon adding it to cloud code.
 
 Web3 API responses for token balances have **decimals **and **balance **in Wei fields:
 

--- a/moralis-server/tools/moralis-units.md
+++ b/moralis-server/tools/moralis-units.md
@@ -42,6 +42,7 @@ const tokenValue = Moralis.Units.FromWei("2000000000000000000", 6)
 //If you do not specify decimals, 18 decimals will be automatically used
 const tokenValue = Moralis.Units.FromWei("2000000000000000000")
 ```
+Note that this function is not available on cloud code. You can use it in the SDK only.
 
 Web3 API responses for token balances have **decimals **and **balance **in Wei fields:
 

--- a/moralis-server/tools/moralis-units.md
+++ b/moralis-server/tools/moralis-units.md
@@ -43,6 +43,7 @@ const tokenValue = Moralis.Units.FromWei("2000000000000000000", 6)
 const tokenValue = Moralis.Units.FromWei("2000000000000000000")
 ```
 Note that this function is not available on cloud code. You can use it in the SDK only. We are very soon adding it to cloud code.
+In the meantime, In javascript it would be wei = eth_amount*10e17. Not *10e18 . e counts as the 10 and *10e18 would multiply your eth by one order of magnitude too many!
 
 Web3 API responses for token balances have **decimals **and **balance **in Wei fields:
 


### PR DESCRIPTION
Currently this function is not available on cloud code. You can use it in the SDK only.

Found the answer here https://forum.moralis.io/t/moralis-units-fromwei-undefined-on-cloud-function/3368 
but if it was written in the docs it would save me 1-2 hours of debugging.
