### PR TITLE
documentation: add missing code from modifying objects on save example

### DIFF
--- a/moralis-dapp/cloud-code/triggers.md
+++ b/moralis-dapp/cloud-code/triggers.md
@@ -78,6 +78,8 @@ Moralis.Cloud.beforeSave("Review", (request) => {
     // Truncate and add a ...
     request.object.set("comment", comment.substring(0, 137) + "...");
   }
+  // ...
+  return request.object
 });
 ```
 


### PR DESCRIPTION
In order for changes made to the object for which we write the beforeSave trigger to be saved in the database, the modified object must be returned

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 Read the Moralis Contribute to Docs Guide: https://docs.moralis.io/introduction/contribute-to-docs
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes if it is possible.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->
## Checklist

* [x] Have you followed the guidelines in our [Contributing document](https://docs.moralis.io/introduction/contribute-to-docs) ?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/MoralisWeb3/MoralisDocumentation/pulls) for the same update/change?
- [ ] If it is a core feature, have you added thorough tests?

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue/code)
- [ ] New feature (non-breaking change which adds functionality)

## Description



## Related Issues & Documents
[Issue](https://github.com/MoralisWeb3/MoralisDocumentation/issues/136)
