### PR TITLE
Transaction.wait / resolve transaction result

### DIFF
--- a/moralis-dapp/web3/web3.md
+++ b/moralis-dapp/web3/web3.md
@@ -376,7 +376,7 @@ const name = await Moralis.executeFunction({
 * The return value if the function is read-only
 * A [transaction response](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionResponse), if the function writes on-chain.
 
-You can resolve the transaction response into a receipt, by waiting until the transaction has been confirmed. For example, to wait for 3 confirmations:
+You can resolve the transaction response into a receipt, by waiting until the transaction has been confirmed. For example, to wait for 1 confirmation:
 
 ```javascript
 const options = {
@@ -387,6 +387,12 @@ const options = {
 };
 const transaction = await Moralis.executeFunction(options);
 const result = await transaction.wait();
+```
+
+To wait for 5 confirmations:
+
+```javascript
+const result = await transaction.wait(5);
 ```
 
 ## Events


### PR DESCRIPTION
[No number in wait means 1 confirmation, 5 would mean 5 confirmations](https://github.com/MoralisWeb3/Moralis-JS-SDK/blob/main/CHANGELOG.md#return-values-of-moralisexecutefunction-and-moralistransfer).

