### PR TITLE
changed `token_address` to `tokenAddresses` which seems to be current syntax for moralis-v1, 

### DIFF
--- a/moralis-dapp/web3-api/nft-api.md
+++ b/moralis-dapp/web3-api/nft-api.md
@@ -381,7 +381,7 @@ Returns an object with the NFT count for the specified contract and an NFT array
 * `cursor` (optional): The next page of data to retrieve. Next page cursor value returned from each request.
 * `limit`(optional): limit (max 100).
 * `address` (optional): The owner of a given token (i.e. `0x1a2b3x...`). If specified, the user attached to the query is ignored and the address will be used instead.
-* `token_address`(required): Address of the contract
+* `tokenAddresses`(required): Array of contract addresses
 
 {% tabs %}
 {% tab title="JS" %}
@@ -406,7 +406,7 @@ const fetchNFTsForContract = async () => {
   const options = {
     chain: "polygon",
     address: "0x75e3e9c92162e62000425c98769965a76c2e387a",
-    token_address: "0x2953399124F0cBB46d2CbACD8A89cF0599974963",
+    tokenAddresses: ["0x2953399124F0cBB46d2CbACD8A89cF0599974963],
   };
   const polygonNFTs = await Web3Api.account.getNFTsForContract(options);
   console.log(polygonNFTs);

--- a/moralis-dapp/web3-api/nft-api.md
+++ b/moralis-dapp/web3-api/nft-api.md
@@ -406,7 +406,7 @@ const fetchNFTsForContract = async () => {
   const options = {
     chain: "polygon",
     address: "0x75e3e9c92162e62000425c98769965a76c2e387a",
-    tokenAddresses: ["0x2953399124F0cBB46d2CbACD8A89cF0599974963],
+    tokenAddresses: ["0x2953399124F0cBB46d2CbACD8A89cF0599974963"],
   };
   const polygonNFTs = await Web3Api.account.getNFTsForContract(options);
   console.log(polygonNFTs);


### PR DESCRIPTION


## Type of Change

- [x] Documentation update
- [x] Bug fix (non-breaking change which fixes an issue/code)
- [?] New feature (non-breaking change which adds functionality)

## Description

i noticed it threw this with the old documentation:
![image](https://user-images.githubusercontent.com/5776918/215721547-6473bd08-2a5a-46ff-80f7-345cd7650c23.png)

## Related Issues & Documents

changed `token_address` to `tokenAddresses` which seems to be current syntax for moralis-v1, 
